### PR TITLE
Resolved : Missing Favicon and OCD Logo in footer #399

### DIFF
--- a/html/join_30DayOfJs.html
+++ b/html/join_30DayOfJs.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>OCD-30DaysOfJs</title>
-    <link rel="icon" type="image/x-icon" href="./public/ocdlogo.png" />
+    <link rel="icon" type="image/x-icon" href="../public/ocdlogo.png" />
     <link
       href="https://cdn.jsdelivr.net/npm/remixicon@3.4.0/fonts/remixicon.css"
       rel="stylesheet"
@@ -129,7 +129,7 @@
             <a href="index.html" class="footer-logo-link">
               <img
                 class="footer-logo"
-                src="./public/ocdlogo.png"
+                src="../public/ocdlogo.png"
                 alt="OCD Logo"
               />
             </a>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/e24cf2c2-790e-4f0e-954c-e4f92b3763f8)
